### PR TITLE
Pinning readline version to avoid conflicts downstream

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-   number: 1
+   number: 2
    skip: true  # [win]
    skip: true  # [py3k]
 
@@ -36,6 +36,7 @@ requirements:
      - openblas 0.2.20|0.2.20.*
      - gsl 2.2.*
      - krb5 1.14.*
+     - readline 7.0
     
  run:
      - python
@@ -54,6 +55,7 @@ requirements:
      - openblas 0.2.20|0.2.20.*
      - gsl 2.2.*
      - krb5 1.14.*
+     - readline 7.0
 
 
 test:


### PR DESCRIPTION
For some reason build 1 has got the readline 6 version, which is not compatible with many things in conda-forge, like matplotlib...